### PR TITLE
Skip CocoaPods

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -6,9 +6,9 @@ platform :ios do
 
   before_all do
     xcversion(version: ENV["XCODE_VERSION"] || '~> 8.2.0')
-    if !(ENV["SKIP_COCOAPODS"] || false) {
+    if !(ENV["SKIP_COCOAPODS"] || false) 
       cocoapods(silent: true, repo_update: true)
-    }
+    end
   end
   
   after_all do

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -6,7 +6,7 @@ platform :ios do
 
   before_all do
     xcversion(version: ENV["XCODE_VERSION"] || '~> 8.2.0')
-    if (!(ENV["SKIP_COCOAPODS"] || false)) {
+    if !(ENV["SKIP_COCOAPODS"] || false) {
       cocoapods(silent: true, repo_update: true)
     }
   end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -6,7 +6,9 @@ platform :ios do
 
   before_all do
     xcversion(version: ENV["XCODE_VERSION"] || '~> 8.2.0')
-    cocoapods(silent: true, repo_update: true)
+    if (!(ENV["SKIP_COCOAPODS"] || false)) {
+      cocoapods(silent: true, repo_update: true)
+    }
   end
   
   after_all do


### PR DESCRIPTION
Projects that don’t use CocoaPods can set the `SKIP_COCOAPODS` setting to `true`.