### PR TITLE
Allow for specifying test output directory.

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -21,6 +21,7 @@ platform :ios do
       configuration: "Debug",
       output_types: "junit",
       device: ENV["DEVICE"] || 'iPhone 7 (10.2)',
+      output_directory: ENV["TEST_OUTPUT_DIRECTORY"] || './fastlane/test_output'
     )
   end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -21,7 +21,7 @@ platform :ios do
       configuration: "Debug",
       output_types: "junit",
       device: ENV["DEVICE"] || 'iPhone 7 (10.2)',
-      output_directory: ENV["TEST_OUTPUT_DIRECTORY"] || './fastlane/test_output'
+      output_directory: ENV["TEST_OUTPUT_DIRECTORY"] || './fastlane/test_output',
     )
   end
 


### PR DESCRIPTION
For multi-platform projects, this will allow us to specify an output directory for tests so that each run of `scan` doesn’t overwrite the existing test output.