### PR TITLE
Add Carthage to dependency updater

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -128,8 +128,9 @@ desc "Updates project dependencies in Bundler and CocoaPods, then sends a pull r
 lane :updateDependencies do
     fastlane_require 'fastlane-plugin-git_status'
     xcversion(version: ENV["XCODE_VERSION"] || '~> 10.1')
-    bundle_update
-    cocoapods_update
+    bundle_update if File.exist?("../Gemfile.lock")
+    cocoapods_update if File.exist?("../Podfile.lock")
+    carthage(command: "update", no_build: true) if File.exist?("../Cartfile.resolved")
     sendUpdatePullRequest unless git_status.empty?
 end
 


### PR DESCRIPTION
Fixes #16. When running `updateDependencies`, the dependency updater will now:

- Look for a `Gemfile.lock` and, if it’s present, run `bundle update`.
- Look for a `Podfile.lock` and, if it’s present, run `pod update`. This was already smart enough to know if it should prefix the command with `bundle exec`.
- Look for a `Cartfile.resolved` and, if it’s present, run `carthage update`. This uses the `--no-build` option to skip building the dependencies.

Jobs that use Carthage should set the `FL_CARTHAGE_USE_SSH` and `FL_CARTHAGE_PLATFORM` environment variables (if you leave the latter blank, it’ll build dependencies for all four Apple platforms).