### PR TITLE
Added iOS lane: set_build_number_to_commit_count

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -33,6 +33,11 @@ platform :ios do
     end
   end
 
+  desc "Sets the build number to the current commit count."
+  lane :set_build_number_to_commit_count do
+    increment_build_number(build_number: number_of_commits)
+  end
+
   desc "Build the archive and ipa with options (configuration (Release), include_bitcode (false), export_method (enterprise))."
   lane :build do |options|
     options[:configuration] ||= "Release"

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -84,6 +84,11 @@ Runs all the tests.
 fastlane ios incrementBuildNumber
 ```
 Sets the version number to the given version or, if none is given, increments it.
+### ios set_build_number_to_commit_count
+```
+fastlane ios set_build_number_to_commit_count
+```
+Sets the build number to the current commit count.
 ### ios build
 ```
 fastlane ios build


### PR DESCRIPTION
Added the option to set the build number of an iOS project/app to the current count of commits on the current branch (e.g. `master`) in the git repository.