### PR TITLE
Fixed casing of setBuildNumberToCommitCount lane

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -34,7 +34,7 @@ platform :ios do
   end
 
   desc "Sets the build number to the current commit count."
-  lane :set_build_number_to_commit_count do
+  lane :setBuildNumberToCommitCount do
     increment_build_number(build_number: number_of_commits)
   end
 

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -84,9 +84,9 @@ Runs all the tests.
 fastlane ios incrementBuildNumber
 ```
 Sets the version number to the given version or, if none is given, increments it.
-### ios set_build_number_to_commit_count
+### ios setBuildNumberToCommitCount
 ```
-fastlane ios set_build_number_to_commit_count
+fastlane ios setBuildNumberToCommitCount
 ```
 Sets the build number to the current commit count.
 ### ios build


### PR DESCRIPTION
I accidentally shipped this lane using snake_case instead of camelCase.