### PR TITLE
Added more release notes/changelog options when uploading to Beta

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -56,17 +56,17 @@ platform :ios do
   desc "Upload a local IPA to Crashlytics with (group)."
   desc "#### Options"
   desc " * **`generate_changelog`**: Whether or not to generate a changelog as the release notes (boolean – default: `false`)"
-  desc " * **`changelog_source`**: The source to use to generate the changelog (e.g. `\"git\"`, `\"jenkins\"`, `\"pr\"` – default: `\"git\"`)"
+  desc " * **`changelog_type`**: The type of changelog to generate (e.g. `\"git\"`, `\"jenkins\"`, `\"pr\"` – default: `\"git\"`)"
   desc " * **`release_notes`**: A string to set as the release notes; overrides any generated changelog."
   lane :uploadToCrashlytics do |options|
     options[:generate_changelog] ||= false
-    options[:changelog_source] ||= "git"
+    options[:changelog_type] ||= "git"
 
     raise "uploadToCrashlytics: A Crashlytics group must be passed as an option." unless options[:group]
 
     unless options.key?(:release_notes)
       if options[:generate_changelog] == true
-        case options[:changelog_source]
+        case options[:changelog_type]
           when "jenkins"
             make_changelog_from_jenkins
 
@@ -101,7 +101,7 @@ platform :ios do
     uploadToCrashlytics(
       group: options[:group], 
       generate_changelog: options[:generate_changelog], 
-      changelog_source: options[:changelog_source], 
+      changelog_type: options[:changelog_type], 
       release_notes: option[:release_notes]
     )
   end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -56,7 +56,7 @@ platform :ios do
   desc "Upload a local IPA to Crashlytics with (group)."
   desc "#### Options"
   desc " * **`generate_changelog`**: Whether or not to generate a changelog as the release notes (boolean – default: `false`)"
-  desc " * **`changelog_source`**: The source to use to generate the changelog (e.g. `\"git\"`, `\"jenkins\"` – default: `"git"`)"
+  desc " * **`changelog_source`**: The source to use to generate the changelog (e.g. `\"git\"`, `\"jenkins\"`, `\"pr\"` – default: `\"git\"`)"
   desc " * **`release_notes`**: A string to set as the release notes; overrides any generated changelog."
   lane :uploadToCrashlytics do |options|
     options[:generate_changelog] ||= false
@@ -69,6 +69,11 @@ platform :ios do
         case options[:changelog_source]
           when "jenkins"
             make_changelog_from_jenkins
+
+          when "pr"
+            UI.error("uploadToCrashlytics: Environment variable for PR ID is not set (ghprbPullId).") unless ENV.key?("ghprbPullId")
+            options[:release_notes] = "PR: ##{ENV["ghprbPullId"]} (#{ENV["GIT_BRANCH"]})"
+
           else 
             changelog_from_git_commits
         end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -54,16 +54,31 @@ platform :ios do
   end
   
   desc "Upload a local IPA to Crashlytics with (group)."
+  desc "#### Options"
+  desc " * **`generate_changelog`**: Whether or not to generate a changelog as the release notes (boolean – default: `false`)"
+  desc " * **`changelog_source`**: The source to use to generate the changelog (e.g. `\"git\"`, `\"jenkins\"` – default: `"git"`)"
+  desc " * **`release_notes`**: A string to set as the release notes; overrides any generated changelog."
   lane :uploadToCrashlytics do |options|
+    options[:generate_changelog] ||= false
+    options[:changelog_source] ||= "git"
+
     raise "uploadToCrashlytics: A Crashlytics group must be passed as an option." unless options[:group]
-    
-    if options[:generate_changelog] == true 
-      changelog_from_git_commits
+
+    unless options.key?(:release_notes)
+      if options[:generate_changelog] == true
+        case options[:changelog_source]
+          when "jenkins"
+            make_changelog_from_jenkins
+          else 
+            changelog_from_git_commits
+        end
+      end
     end
     
     crashlytics(
       groups: options[:group],
-      notifications: 'true'
+      notes: options[:release_notes], # if release_notes is nil, this will be overriden by any generated changelog.
+      notifications: true
     )
   end
 
@@ -78,7 +93,12 @@ platform :ios do
 
     build(configuration: options[:configuration], include_bitcode: options[:include_bitcode], export_method: options[:export_method])
 
-    uploadToCrashlytics(group: options[:group], generate_changelog: options[:generate_changelog])
+    uploadToCrashlytics(
+      group: options[:group], 
+      generate_changelog: options[:generate_changelog], 
+      changelog_source: options[:changelog_source], 
+      release_notes: option[:release_notes]
+    )
   end
   
   # Custom actions

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -74,8 +74,11 @@ platform :ios do
             UI.error("uploadToCrashlytics: Environment variable for PR ID is not set (ghprbPullId).") unless ENV.key?("ghprbPullId")
             options[:release_notes] = "PR: ##{ENV["ghprbPullId"]} (#{ENV["GIT_BRANCH"]})"
 
-          else 
+          when "git"
             changelog_from_git_commits
+
+          else 
+            UI.error("Unrecognized changelog_type: #{options[:changelog_type]}")
         end
       end
     end

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -99,6 +99,14 @@ Build the archive and ipa with options (configuration (Release), include_bitcode
 fastlane ios uploadToCrashlytics
 ```
 Upload a local IPA to Crashlytics with (group).
+
+#### Options
+
+ * **`generate_changelog`**: Whether or not to generate a changelog as the release notes (e.g. `true`, `false` – default: `false`)
+
+ * **`changelog_source`**: The source to use to generate the changelog (e.g. `"git"`, `"jenkins"` – default: `git`)
+
+ * **`release_notes`**: A string to set as the release notes; overrides any generated changelog.
 ### ios beta
 ```
 fastlane ios beta

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -104,7 +104,7 @@ Upload a local IPA to Crashlytics with (group).
 
  * **`generate_changelog`**: Whether or not to generate a changelog as the release notes (boolean – default: `false`)
 
- * **`changelog_source`**: The source to use to generate the changelog (e.g. `"git"`, `"jenkins"`, `"pr"` – default: `"git"`)
+ * **`changelog_type`**: The type of changelog to generate (e.g. `"git"`, `"jenkins"`, `"pr"` – default: `"git"`)
 
  * **`release_notes`**: A string to set as the release notes; overrides any generated changelog.
 ### ios beta

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -102,9 +102,9 @@ Upload a local IPA to Crashlytics with (group).
 
 #### Options
 
- * **`generate_changelog`**: Whether or not to generate a changelog as the release notes (e.g. `true`, `false` – default: `false`)
+ * **`generate_changelog`**: Whether or not to generate a changelog as the release notes (boolean – default: `false`)
 
- * **`changelog_source`**: The source to use to generate the changelog (e.g. `"git"`, `"jenkins"` – default: `git`)
+ * **`changelog_source`**: The source to use to generate the changelog (e.g. `"git"`, `"jenkins"`, `"pr"` – default: `"git"`)
 
  * **`release_notes`**: A string to set as the release notes; overrides any generated changelog.
 ### ios beta


### PR DESCRIPTION
Previously, the only option for release notes uploaded for Beta builds
was to use the git commit log (since last tag).

I've added 2 more options for Beta release notes:
  1. Added the option to use the Jenkins changes (since last builg) as changelog for release notes.
  2. Added the ability to pass a string to be used as the release notes (e.g. "PR #123").