### PR TITLE
Bugfix: Fixed a typo in the beta lane.

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -105,7 +105,7 @@ platform :ios do
       group: options[:group], 
       generate_changelog: options[:generate_changelog], 
       changelog_type: options[:changelog_type], 
-      release_notes: option[:release_notes]
+      release_notes: options[:release_notes]
     )
   end
   


### PR DESCRIPTION
`option` is being used instead of `options`, which is causing a fatal error for any job trying to run the `beta` lane.