### PR TITLE
Make updates for Firebase App Distribution

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,6 @@ source "https://rubygems.org"
 
 gem "fastlane"
 gem "xcode-install"
+
+plugins_path = File.join(File.dirname(__FILE__), 'fastlane', 'Pluginfile')
+eval_gemfile(plugins_path) if File.exist?(plugins_path)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,6 +64,8 @@ GEM
       xcodeproj (>= 1.8.1, < 2.0.0)
       xcpretty (~> 0.3.0)
       xcpretty-travis-formatter (>= 0.0.3)
+    fastlane-plugin-firebase_app_distribution (0.1.2)
+    fastlane-plugin-git_status (0.1.3)
     gh_inspector (1.1.3)
     google-api-client (0.23.9)
       addressable (~> 2.5, >= 2.5.1)
@@ -157,6 +159,8 @@ PLATFORMS
 
 DEPENDENCIES
   fastlane
+  fastlane-plugin-firebase_app_distribution
+  fastlane-plugin-git_status
   xcode-install
 
 BUNDLED WITH

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -109,7 +109,7 @@ platform :ios do
     )
   end
   
-  desc "Upload a local IPA to Firebase App Distribution with (app_id) and (group)."
+  desc "Upload a local IPA to Firebase App Distribution with (app_id) and (groups)."
   desc "#### Options"
   desc " * **`generate_changelog`**: Whether or not to generate a changelog as the release notes (boolean – default: `false`)"
   desc " * **`changelog_type`**: The type of changelog to generate (e.g. `\"git\"`, `\"jenkins\"`, `\"pr\"` – default: `\"git\"`)"
@@ -119,7 +119,7 @@ platform :ios do
     options[:changelog_type] ||= "git"
 
     raise "uploadToFirebase: An app ID must be passed as an option (e.g. `\"1:123456789:ios:abcd1234\"`)." unless options[:app_id]
-    raise "uploadToFirebase: A tester group must be passed as an option." unless options[:group]
+    raise "uploadToFirebase: A tester group must be passed as an option." unless options[:groups]
 
     unless options.key?(:release_notes)
       if options[:generate_changelog] == true
@@ -142,8 +142,8 @@ platform :ios do
 
     firebase_app_distribution(
       app: options[:app_id],
-      release_notes: options[:release_notes], # if release_notes is nil, this will be overriden by any generated changelog.
-      testers: options[:group]
+      release_notes: options[:release_notes],
+      groups: options[:groups]
     )
   end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -109,6 +109,44 @@ platform :ios do
     )
   end
   
+  desc "Upload a local IPA to Firebase App Distribution with (app_id) and (group)."
+  desc "#### Options"
+  desc " * **`generate_changelog`**: Whether or not to generate a changelog as the release notes (boolean – default: `false`)"
+  desc " * **`changelog_type`**: The type of changelog to generate (e.g. `\"git\"`, `\"jenkins\"`, `\"pr\"` – default: `\"git\"`)"
+  desc " * **`release_notes`**: A string to set as the release notes; overrides any generated changelog."
+  lane :uploadToFirebase do |options|
+    options[:generate_changelog] ||= false
+    options[:changelog_type] ||= "git"
+
+    raise "uploadToFirebase: An app ID must be passed as an option (e.g. `\"1:123456789:ios:abcd1234\"`)." unless options[:app_id]
+    raise "uploadToFirebase: A tester group must be passed as an option." unless options[:group]
+
+    unless options.key?(:release_notes)
+      if options[:generate_changelog] == true
+        case options[:changelog_type]
+          when "jenkins"
+            make_changelog_from_jenkins
+
+          when "pr"
+            UI.error("uploadToCrashlytics: Environment variable for PR ID is not set (ghprbPullId).") unless ENV.key?("ghprbPullId")
+            options[:release_notes] = "PR: ##{ENV["ghprbPullId"]} (#{ENV["GIT_BRANCH"]})"
+
+          when "git"
+            changelog_from_git_commits
+
+          else
+            UI.error("Unrecognized changelog_type: #{options[:changelog_type]}")
+        end
+      end
+    end
+
+    firebase_app_distribution(
+      app: options[:app_id],
+      release_notes: options[:release_notes], # if release_notes is nil, this will be overriden by any generated changelog.
+      testers: options[:group]
+    )
+  end
+
   # Custom actions
   
   desc "Builds and uploads to Crashlytics a QA build."

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -3,3 +3,4 @@
 # Ensure this file is checked in to source control!
 
 gem 'fastlane-plugin-git_status'
+gem 'fastlane-plugin-firebase_app_distribution'


### PR DESCRIPTION
Updates the template with a lane to upload IPA to Firebase App Distribution.
Adds the `fastlane-plugin-firebase_app_distribution` plugin to the Pluginfile.

>These changes will not work until our nodes have the [Firebase CLI](https://firebase.google.com/docs/cli#install_the_firebase_cli) installed.