### PR TITLE
Add support for export_options on build lane

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -92,16 +92,21 @@ platform :ios do
     )
   end
 
-  desc "Build and upload to Crashlytics with (configuration (Release)), (include_bitcode (false)), (export_method (enterprise)), and (group)."
+  desc "Build and upload to Crashlytics with (configuration (Release)), (include_bitcode (false)), (export_method (enterprise)), (export_options ({})) and (group)."
   lane :beta do |options|
     options[:configuration] ||= "Release"
     options[:include_bitcode] ||= false
     options[:export_method] ||= "enterprise"
     options[:generate_changelog] ||= false
+    options[:export_options] ||= {}
 
     raise "beta: A Crashlytics group must be passed as an option." unless options[:group]
 
-    build(configuration: options[:configuration], include_bitcode: options[:include_bitcode], export_method: options[:export_method])
+    build(configuration: options[:configuration], 
+      include_bitcode: options[:include_bitcode], 
+      export_method: options[:export_method],
+      export_options: options[:export_options]
+    )
 
     uploadToCrashlytics(
       group: options[:group], 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -43,7 +43,7 @@ platform :ios do
     options[:configuration] ||= "Release"
     options[:include_bitcode] ||= false
     options[:export_method] ||= "enterprise"
-    options[:export_options] ||= { }
+    options[:export_options] ||= {}
     
     installProfiles
     

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -43,13 +43,15 @@ platform :ios do
     options[:configuration] ||= "Release"
     options[:include_bitcode] ||= false
     options[:export_method] ||= "enterprise"
+    options[:export_options] ||= { }
     
     installProfiles
     
     gym(
       configuration: options[:configuration],
       include_bitcode: options[:include_bitcode],
-      export_method: options[:export_method]
+      export_method: options[:export_method],
+      export_options: options[:export_options]
     )
   end
   

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -38,7 +38,7 @@ platform :ios do
     increment_build_number(build_number: number_of_commits)
   end
 
-  desc "Build the archive and ipa with options (configuration (Release), include_bitcode (false), export_method (enterprise))."
+  desc "Build the archive and ipa with options (configuration (Release), include_bitcode (false), export_method (enterprise)), export_options ({})."
   lane :build do |options|
     options[:configuration] ||= "Release"
     options[:include_bitcode] ||= false


### PR DESCRIPTION
### What does this PR do? :soccer:
This PR adds the ability to pass the `export_options` parameter to the `build` lane which is then passed down to the `gym` lane. 

#### Why was this added? ❓
The `export_options` parameter was added to resolve the `error: exportArchive: IPA processing failed` error when running gym on projects that set `include_bitcode` to false. To fix the error the following needs to be passed to `gym`, `export_options: { compileBitcode: false }`

### Tell me about any important implementation details. :construction:
If no `export_options` parameter is passed then an empty dictionary is used.