### PR TITLE
Add PR link to generated PR notes

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -74,7 +74,7 @@ platform :ios do
 
           when "pr"
             UI.error("uploadToCrashlytics: Environment variable for PR ID is not set (ghprbPullId).") unless ENV.key?("ghprbPullId")
-            options[:release_notes] = "PR: ##{ENV["ghprbPullId"]} Branch:(#{ENV["GIT_BRANCH"]}) PR Link:#{ENV["ghprbPullLink"]}"
+            options[:release_notes] = "PR: ##{ENV["ghprbPullId"]}\nBranch: (#{ENV["GIT_BRANCH"]})\nPR Link: #{ENV["ghprbPullLink"]}"
 
           when "git"
             changelog_from_git_commits
@@ -139,7 +139,7 @@ platform :ios do
 
           when "pr"
             UI.error("uploadToCrashlytics: Environment variable for PR ID is not set (ghprbPullId).") unless ENV.key?("ghprbPullId")
-            options[:release_notes] = "PR: ##{ENV["ghprbPullId"]} Branch:(#{ENV["GIT_BRANCH"]}) PR Link:#{ENV["ghprbPullLink"]}"
+            options[:release_notes] = "PR: ##{ENV["ghprbPullId"]}\nBranch: (#{ENV["GIT_BRANCH"]})\nPR Link: #{ENV["ghprbPullLink"]}"
 
           when "git"
             changelog_from_git_commits

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -74,7 +74,7 @@ platform :ios do
 
           when "pr"
             UI.error("uploadToCrashlytics: Environment variable for PR ID is not set (ghprbPullId).") unless ENV.key?("ghprbPullId")
-            options[:release_notes] = "PR: ##{ENV["ghprbPullId"]} (#{ENV["GIT_BRANCH"]})"
+            options[:release_notes] = "PR: ##{ENV["ghprbPullId"]} Branch:(#{ENV["GIT_BRANCH"]}) PR Link:#{ENV["ghprbPullLink"]}"
 
           when "git"
             changelog_from_git_commits
@@ -139,7 +139,7 @@ platform :ios do
 
           when "pr"
             UI.error("uploadToCrashlytics: Environment variable for PR ID is not set (ghprbPullId).") unless ENV.key?("ghprbPullId")
-            options[:release_notes] = "PR: ##{ENV["ghprbPullId"]} (#{ENV["GIT_BRANCH"]})"
+            options[:release_notes] = "PR: ##{ENV["ghprbPullId"]} Branch:(#{ENV["GIT_BRANCH"]}) PR Link:#{ENV["ghprbPullLink"]}"
 
           when "git"
             changelog_from_git_commits


### PR DESCRIPTION
One of the requests from QA we had on DTE was that PR builds have a URL that points back to the PR in the notes. Figured it might be worth adding it here, instead of adding it only to DTE.