### PR TITLE
Refactor Update Dependencies

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -227,11 +227,16 @@ lane :updateDependencies do |options|
 end
 
 desc "Sends a pull request with the current changes to dependencies"
-lane :sendUpdatePullRequest do
+lane :sendUpdatePullRequest do |options|
+    options[:branchname] ||= ENV["UPDATE_DEPENDENCIES_BRANCH"]
+    options[:base] ||= "master"
+    options[:pullRequestTitle] ||= "Update Dependencies"
+
     fastlane_require 'fastlane-plugin-git_status'
 
-    branchname = ENV["UPDATE_DEPENDENCIES_BRANCH"]
-
+    branchname = options[:branchname]
+    base = options[:base]
+    
     create_git_branch(
       branchname: branchname
     )
@@ -261,8 +266,8 @@ lane :sendUpdatePullRequest do
       api_token: ENV["GITHUB_TOKEN"],
       repo: ENV["GITHUB_REPO"],
       head: branchname,
-      base: "master",
-      title: "Update Dependencies"
+      base: base,
+      title: options[:pullRequestTitle]
     )
 end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -207,6 +207,10 @@ lane :installProfiles do
 end
 
 desc "Updates project dependencies in Bundler and CocoaPods, then sends a pull request if there are changes"
+desc "#### Options"
+  desc " * **`branchname`**: Accepts an optional value to set the dependency updater branch. If no value is passed in, it will default to the ENV variable name."
+  desc " * **`base`**: Accepts an optional value to set the base branch for the created dependency update PR. If no value is passed in, it will default to master." 
+  desc " * **`pullRequestTitle`**: Accepts an optional value to set the title for the created dependency update PR. If no value is passed in, it will default to Update Dependencies."
 lane :updateDependencies do |options|
     options[:branchname] ||= ENV["UPDATE_DEPENDENCIES_BRANCH"]
     options[:base] ||= "master"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -207,13 +207,23 @@ lane :installProfiles do
 end
 
 desc "Updates project dependencies in Bundler and CocoaPods, then sends a pull request if there are changes"
-lane :updateDependencies do
+lane :updateDependencies do |options|
+    options[:branchname] ||= ENV["UPDATE_DEPENDENCIES_BRANCH"]
+    options[:base] ||= "master",
+    options[:pullRequestTitle] ||= "Update Dependencies"
+
     fastlane_require 'fastlane-plugin-git_status'
-    xcversion(version: ENV["XCODE_VERSION"] || '~> 10.2')
+
+    xcversion(version: ENV["XCODE_VERSION"] || '~> 11.3')
     bundle_update if File.exist?("../Gemfile.lock")
     cocoapods_update if File.exist?("../Podfile.lock")
     carthage(command: "update", no_build: true) if File.exist?("../Cartfile.resolved")
-    sendUpdatePullRequest unless git_status.empty?
+
+    sendUpdatePullRequest(
+      branchname: options[:branchname], 
+      base: options[:base],
+      pullRequestTitle: options[:pullRequestTitle]
+    ) unless git_status.empty?
 end
 
 desc "Sends a pull request with the current changes to dependencies"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -209,7 +209,7 @@ end
 desc "Updates project dependencies in Bundler and CocoaPods, then sends a pull request if there are changes"
 lane :updateDependencies do |options|
     options[:branchname] ||= ENV["UPDATE_DEPENDENCIES_BRANCH"]
-    options[:base] ||= "master",
+    options[:base] ||= "master"
     options[:pullRequestTitle] ||= "Update Dependencies"
 
     fastlane_require 'fastlane-plugin-git_status'
@@ -220,7 +220,7 @@ lane :updateDependencies do |options|
     carthage(command: "update", no_build: true) if File.exist?("../Cartfile.resolved")
 
     sendUpdatePullRequest(
-      branchname: options[:branchname], 
+      branchname: options[:branchname],
       base: options[:base],
       pullRequestTitle: options[:pullRequestTitle]
     ) unless git_status.empty?


### PR DESCRIPTION
## What does this PR do? 🚀 

paired with @OviBortas  and @GeorgeRoyce 🥇
 
This PR allows users to pass in `options` for the `updateDepenedencies` method that are then passed down to `sendUpdatePullRequest` method. 

This grants the ability to update dependencies for specific branches, in our scenario `feature branches`.  

The newly added options below start with a default value, but can also be set when they are passed in to `updateDependencies`.

**Parameters:**
`options[:branchname] ||= ENV["UPDATE_DEPENDENCIES_BRANCH"]`
`options[:base] ||= "master"`
`options[:pullRequestTitle] ||= "Update Dependencies"`