### PR TITLE
Fix release_notes Condition to Generate Notes

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -118,9 +118,6 @@ platform :ios do
           raise "Unrecognized changelog_type: #{options[:changelog_type]}"
       end
     end
-    
-    UI.message("changelog_type: #{options[:changelog_type]}")
-    UI.message("release_notes: #{options[:release_notes]}")
 
     firebase_app_distribution(
       firebase_cli_token: options[:firebase_cli_token],


### PR DESCRIPTION
Previous syntax was whether the `release_notes` key existed at all. It did, as `nil`, and so the branch wasn't hit. This PR updates to check the `options` hash value directly.