### PR TITLE
Remove break statement

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -112,7 +112,6 @@ platform :ios do
           
         when "none"
           UI.message("uploadToFirebase called with a changelog_type of none.")
-          break
 
         else
           raise "Unrecognized changelog_type: #{options[:changelog_type]}"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -98,7 +98,7 @@ platform :ios do
     raise "uploadToFirebase: A tester group must be passed as an option." unless options[:groups]
     raise "uploadToFirebase: A CLI token must be provided, either through the firebase_cli_token parameter or FIREBASE_TOKEN environment variable." unless options[:firebase_cli_token]
 
-    unless options.key?(:release_notes)
+    unless options[:release_notes]
       case options[:changelog_type]
         when "jenkins"
           make_changelog_from_jenkins


### PR DESCRIPTION
Apparently `break` inside a `case` is illegal in newer Ruby versions, so remove it.