### PR TITLE
Disable SPM Update

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -281,7 +281,7 @@ lane :updateDependencies do |options|
     bundle_update if File.exist?("../Gemfile.lock")
     cocoapods_update if File.exist?("../Podfile.lock")
     carthage(command: "update", no_build: true) if File.exist?("../Cartfile.resolved")
-    updateXcodeSwiftPackages(xcodeResolvedFilePath: options[:xcodeResolvedFilePath])
+    # updateXcodeSwiftPackages(xcodeResolvedFilePath: options[:xcodeResolvedFilePath])
 
     sendUpdatePullRequest(
       branchname: options[:branchname],


### PR DESCRIPTION
This PR disables the SPM automatic update. Not only does it not work correctly (no actual updates unless the node's cache contains a newer version) but it can regress versions if the node's cache is further behind than expected.  We can redo this when Xcode's SPM can update from the command line.